### PR TITLE
Issue #12, Artifacts use filename, not json name property.

### DIFF
--- a/deploy-adf-json/1.1.11/deploy-adf-json.psm1
+++ b/deploy-adf-json/1.1.11/deploy-adf-json.psm1
@@ -377,7 +377,7 @@ An example
 function deployLinkedServiceJSON($ResourceGroupName, $DataFactoryName, $Version, $JsonFile, $Overwrite) {
     switch ($Version) {
         "V2" {
-            $linkedServiceName =  ($JsonFile.Name).Replace('.json', '')
+            $linkedServiceName = (Get-Content $JsonFile | ConvertFrom-Json).name
             if ($Overwrite) {
                 $result = Set-AzureRmDataFactoryV2LinkedService -ResourceGroupName $ResourceGroupName -DataFactoryName $DataFactoryName -Name $linkedServiceName -File $JsonFile.FullName -Force
             } else {
@@ -417,7 +417,7 @@ An example
 function deployDatasetJSON($ResourceGroupName, $DataFactoryName, $Version, $JsonFile, $Overwrite) {
     switch ($Version) {
         "V2" {
-            $datasetName =  ($JsonFile.Name).Replace('.json', '')
+            $datasetName = (Get-Content $JsonFile | ConvertFrom-Json).name
             if ($Overwrite) {
                 $result = Set-AzureRmDataFactoryV2Dataset -ResourceGroupName $ResourceGroupName -DataFactoryName $DataFactoryName -Name $datasetName -File $JsonFile.FullName -Force
             } else {
@@ -457,7 +457,7 @@ An example
 function deployPipelineJSON($ResourceGroupName, $DataFactoryName, $Version, $JsonFile, $Overwrite) {
     switch ($Version) {
         "V2" {
-            $pipelineName =  ($JsonFile.Name).Replace('.json', '')
+            $pipelineName = (Get-Content $JsonFile | ConvertFrom-Json).name
             if ($Overwrite) {
                 $result = Set-AzureRmDataFactoryV2Pipeline -ResourceGroupName $ResourceGroupName -DataFactoryName $DataFactoryName -Name $pipelineName -File $JsonFile.FullName -Force
             } else {
@@ -497,7 +497,7 @@ An example
 function deployTriggerJSON($ResourceGroupName, $DataFactoryName, $Version, $JsonFile, $Overwrite) {
     switch ($Version) {
         "V2" { 
-            $triggerName = ($JsonFile.Name).Replace('.json', '')
+            $triggerName = (Get-Content $JsonFile | ConvertFrom-Json).name
             if ($Overwrite) {
                 $result = Set-AzureRmDataFactoryV2Trigger -ResourceGroupName $ResourceGroupName -DataFactoryName $DataFactoryName -Name $triggerName -File $JsonFile.FullName -Force
             } else {


### PR DESCRIPTION
Modifies code to read the contents of the file and get the name of the service. This way it helps in ordering files using appropriate names to solve dependency (short term), and without breaking code as the artifacts are not named on the file names.

We have a situation where KeyVault is needed to deploy some of the other linkedServices. For the short term we sorted the file names using an integer at the start of the file, but the deploy component breaks as the linked service is named after the file and not the actual name property.

Hope this helps.